### PR TITLE
Added the APIs and DB updates to enable favouriting cities

### DIFF
--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -66,8 +66,37 @@ const deleteCity = async (id) => {
     .del();
 };
 
-const findFavourites = async () => {
-  return await db('profiles');
+// pulls the fav cities which returns as a json objectives for the user ID
+const findFavourites = async (id) => {
+  return await db('profiles').where({ id: id }).column('favs');
+};
+
+// add a new fav city for a user
+const addFavourite = async (id, place) => {
+  let currFavs = await db('profiles').where({ id: id }).column('favs');
+  return await db('profiles')
+    .where({ id: id })
+    .column('favs')
+    .insert(currFavs.append([place.city, place.state]));
+};
+// removes a fav city for a user
+const removeFavourite = async (id, place) => {
+  let currFavs = await db('profiles').where({ id: id }).column('favs');
+  let i = 0;
+  let ind = null;
+  for (i = 0; i < currFavs.length(); i++) {
+    if (place.city == currFavs[i][0] && place.state == currFavs[i][2]) {
+      ind = i;
+      break;
+    }
+  }
+  if (ind != null) {
+    delete currFavs[ind];
+  } else {
+    return false;
+  }
+  await db('profiles').where({ id: id }).column('favs').del();
+  return await db('profiles').where({ id: id }).column('favs').insert(currFavs);
 };
 
 module.exports = {
@@ -81,4 +110,6 @@ module.exports = {
   findCities,
   deleteCity,
   findFavourites,
+  addFavourite,
+  removeFavourite,
 };

--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -66,6 +66,10 @@ const deleteCity = async (id) => {
     .del();
 };
 
+const findFavourites = async () => {
+  return await db('profiles');
+};
+
 module.exports = {
   findAll,
   findBy,
@@ -76,4 +80,5 @@ module.exports = {
   findOrCreateProfile,
   findCities,
   deleteCity,
+  findFavourites,
 };

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -149,4 +149,15 @@ router.delete('/:id/city/:city_id', async (req, res, next) => {
   }
 });
 
+router.get('/favourites', async (req, res) => {
+  Profiles.findFavourites()
+    .then((favs) => {
+      res.status(200).json(favs);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
 module.exports = router;

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -150,7 +150,34 @@ router.delete('/:id/city/:city_id', async (req, res, next) => {
 });
 
 router.get('/favourites', async (req, res) => {
-  Profiles.findFavourites()
+  const id = req.params.id;
+  Profiles.findFavourites(id)
+    .then((favs) => {
+      res.status(200).json(favs);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+router.post('/favourites', async (req, res) => {
+  const id = req.params.id;
+  const place = [req.params.city, req.params.state];
+  Profiles.addFavourite(id, place)
+    .then((favs) => {
+      res.status(200).json(favs);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+router.delete('/favourites', async (req, res) => {
+  const id = req.params.id;
+  const place = [req.params.city, req.params.state];
+  Profiles.removeFavourite(id, place)
     .then((favs) => {
       res.status(200).json(favs);
     })

--- a/data/migrations/20210414210812_add-favs.js
+++ b/data/migrations/20210414210812_add-favs.js
@@ -1,12 +1,13 @@
 // Adds a column for favourites attached to the profile table
 
 exports.up = function (knex) {
-  return knex.schema.table('profiles') function (table){
-      table.json('favs')
-  }
+  return knex.schema.table('profiles', function (table) {
+    table.json('favs');
+  });
 };
 
 exports.down = function (knex) {
-    return knex.schema.table('profiles') function (table){
-        table.dropColumn('favs')
+  return knex.schema.table('profiles', function (table) {
+    table.dropColumn('favs');
+  });
 };

--- a/data/migrations/20210414210812_add-favs.js
+++ b/data/migrations/20210414210812_add-favs.js
@@ -1,0 +1,12 @@
+// Adds a column for favourites attached to the profile table
+
+exports.up = function (knex) {
+  return knex.schema.table('profiles') function (table){
+      table.json('favs')
+  }
+};
+
+exports.down = function (knex) {
+    return knex.schema.table('profiles') function (table){
+        table.dropColumn('favs')
+};

--- a/data/seeds/003_favs.js
+++ b/data/seeds/003_favs.js
@@ -1,0 +1,18 @@
+exports.seed = function (knex) {
+  // Deletes favs existing entries
+  return knex('profiles')
+    .column('fav')
+    .del()
+    .then(function () {
+      return knex('profiles')
+        .where({ profile_id: '00ulthapbErVUwVJy4x6' })
+        .insert([
+          {
+            favs: [
+              ['wichita', 'Kansas'],
+              ['Atlanta', 'Georgia'],
+            ],
+          },
+        ]);
+    });
+};


### PR DESCRIPTION
Trello Link: https://trello.com/c/9GS7vO6l/46-as-a-user-i-would-like-to-save-cities-to-my-profile-so-that-i-can-reference-them-in-the-future 

To enable users to save their favourite cities for future reference, I attached a favourite data attribute to the profile db and created endpoints to pull and edit this data

Broke up my commits by step and files - updated the knex migrations, seeding, profile model, and finally new profile endpoints 

Get - pulls all the favourites for a user
Post - add a new fav city to a profile
Del - removes a fav city from a profile